### PR TITLE
added repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "author": "Zach Carter",
   "license": "MIT",
+  "repository": { "type": "git", "url": "https://github.com/zaach/ebnf-parser.git" },
   "devDependencies": {
     "jison": "0.4.x",
     "lex-parser": "0.1.0",


### PR DESCRIPTION
```
npm WARN package.json ebnf-parser@0.1.5 No repository field.
```

this PR fixes that warning
