### PR TITLE
feature(grammar): allow key-value options

### DIFF
--- a/bnf.l
+++ b/bnf.l
@@ -24,6 +24,7 @@ id                [a-zA-Z][a-zA-Z0-9_-]*
 ":"                     return ':';
 ";"                     return ';';
 "|"                     return '|';
+"="                     return '=';
 "%%"                    this.pushState(ebnf ? 'ebnf' : 'bnf'); return '%%';
 "%ebnf"                 if (!yy.options) yy.options = {}; ebnf = yy.options.ebnf = true;
 "%prec"                 return 'PREC';

--- a/bnf.y
+++ b/bnf.y
@@ -51,8 +51,22 @@ declaration
     ;
 
 options
-    : OPTIONS token_list
+    : OPTIONS options_list
         {$$ = $2;}
+    ;
+
+options_list
+    : options_list option
+        { $$ = $1; $$[$2[0]] = $2[1]; }
+    | option
+        {$$ = {}; $$[$1[0]] = $1[1];}
+    ;
+
+option
+    : symbol
+        {$$ = [$1, true];}
+    | symbol '=' symbol
+        {$$ = [$1, $3];}
     ;
 
 parse_param

--- a/ebnf-parser.js
+++ b/ebnf-parser.js
@@ -27,9 +27,9 @@ bnf.yy.addDeclaration = function (grammar, decl) {
 
     } else if (decl.options) {
         if (!grammar.options) grammar.options = {};
-        for (var i=0; i < decl.options.length; i++) {
-            grammar.options[decl.options[i]] = true;
-        }
+        Object.keys(decl.options).forEach(function(option) {
+            grammar.options[option] = decl.options[option];
+        });
     }
 
 };

--- a/tests/bnf_parse.js
+++ b/tests/bnf_parse.js
@@ -219,3 +219,10 @@ exports["test options"] = function () {
 
     assert.deepEqual(bnf.parse(grammar), expected, "grammar should be parsed correctly");
 };
+
+exports["test key-value options"] = function () {
+    var grammar = "%options foo=bar baz\n%%hello: world;%%";
+    var expected = {bnf: {hello: ["world"]}, options: {foo: 'bar', baz: true}};
+
+    assert.deepEqual(bnf.parse(grammar), expected, "grammar should be parsed correctly");
+};


### PR DESCRIPTION
Now you have ability to specify options in grammar file.
It's enough for me, because I have to declare my module name in my file.
I can do it in JSON file and I want to do it in BNF files as well.

I've tested these changes allow to do it. I will can write like this

```
%options moduleName=myGrammar;
```

Jison will get this option and declare generated parser with proper module name
