### PR TITLE
Record unknown declarations

### DIFF
--- a/bnf.l
+++ b/bnf.l
@@ -34,7 +34,7 @@ id                [a-zA-Z][a-zA-Z0-9_-]*
 "%parse-param"          return 'PARSE_PARAM';
 "%options"              return 'OPTIONS';
 "%lex"[\w\W]*?"/lex"    return 'LEX_BLOCK';
-"%"[a-zA-Z]+[^\r\n]*    /* ignore unrecognized decl */
+"%"[a-zA-Z]+[^\r\n]*    return 'UNKNOWN_DECL';
 "<"[a-zA-Z]*">"         /* ignore type */
 "{{"[\w\W]*?"}}"        yytext = yytext.substr(2, yyleng-4); return 'ACTION';
 "%{"(.|\r|\n)*?"%}"     yytext = yytext.substr(2, yytext.length-4); return 'ACTION';

--- a/bnf.y
+++ b/bnf.y
@@ -48,6 +48,8 @@ declaration
         {$$ = {parseParam: $1};}
     | options
         {$$ = {options: $1};}
+    | UNKNOWN_DECL
+        {$$ = {unknownDecl: $1};}
     ;
 
 options
@@ -90,7 +92,7 @@ production_list
     : production_list production
         {
             $$ = $1;
-            if ($2[0] in $$) 
+            if ($2[0] in $$)
                 $$[$2[0]] = $$[$2[0]].concat($2[1]);
             else
                 $$[$2[0]] = $2[1];
@@ -213,4 +215,3 @@ function extend (json, grammar) {
     json.bnf = ebnf ? transform(grammar) : grammar;
     return json;
 }
-

--- a/ebnf-parser.js
+++ b/ebnf-parser.js
@@ -30,6 +30,9 @@ bnf.yy.addDeclaration = function (grammar, decl) {
         for (var i=0; i < decl.options.length; i++) {
             grammar.options[decl.options[i]] = true;
         }
+    } else if (decl.unknownDecl) {
+      if (!grammar.unknownDecls) grammar.unknownDecls = [];
+      grammar.unknownDecls.push(decl.unknownDecl);
     }
 
 };
@@ -38,4 +41,3 @@ bnf.yy.addDeclaration = function (grammar, decl) {
 var parseLex = function (text) {
     return jisonlex.parse(text.replace(/(?:^%lex)|(?:\/lex$)/g, ''));
 };
-

--- a/tests/bnf_parse.js
+++ b/tests/bnf_parse.js
@@ -87,14 +87,14 @@ exports["test comment with nested *"] = function () {
 
 exports["test token"] = function () {
     var grammar = "%token blah\n%% test: foo bar | baz ; hello: world ;";
-    var expected = {bnf: {test: ["foo bar", "baz"], hello: ["world"]}};
+    var expected = {bnf: {test: ["foo bar", "baz"], hello: ["world"]}, unknownDecls: ['%token blah']};
 
     assert.deepEqual(bnf.parse(grammar), expected, "grammar should be parsed correctly");
 };
 
 exports["test token with type"] = function () {
     var grammar = "%type <type> blah\n%% test: foo bar | baz ; hello: world ;";
-    var expected = {bnf: {test: ["foo bar", "baz"], hello: ["world"]}};
+    var expected = {bnf: {test: ["foo bar", "baz"], hello: ["world"]}, unknownDecls: ['%type <type> blah']};
 
     assert.deepEqual(bnf.parse(grammar), expected, "grammar should be parsed correctly");
 };
@@ -216,6 +216,13 @@ exports["test parse params"] = function () {
 exports["test options"] = function () {
     var grammar = "%options one two\n%%hello: world;%%";
     var expected = {bnf: {hello: ["world"]}, options: {one: true, two: true}};
+
+    assert.deepEqual(bnf.parse(grammar), expected, "grammar should be parsed correctly");
+};
+
+exports["test unknown decls"] = function () {
+    var grammar = "%foo bar\n%foo baz\n%qux { fizzle }\n%%hello: world;%%";
+    var expected = {bnf: {hello: ["world"]}, unknownDecls: ['%foo bar', '%foo baz', '%qux { fizzle }']};
 
     assert.deepEqual(bnf.parse(grammar), expected, "grammar should be parsed correctly");
 };

--- a/transform-parser.js
+++ b/transform-parser.js
@@ -77,7 +77,8 @@ yy: {},
 symbols_: {"error":2,"production":3,"handle":4,"EOF":5,"handle_list":6,"|":7,"expression_suffix":8,"expression":9,"suffix":10,"ALIAS":11,"symbol":12,"(":13,")":14,"*":15,"?":16,"+":17,"$accept":0,"$end":1},
 terminals_: {2:"error",5:"EOF",7:"|",11:"ALIAS",12:"symbol",13:"(",14:")",15:"*",16:"?",17:"+"},
 productions_: [0,[3,2],[6,1],[6,3],[4,0],[4,2],[8,3],[8,2],[9,1],[9,3],[10,0],[10,1],[10,1],[10,1]],
-performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */) {
+performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */
+/**/) {
 /* this == yyval */
 
 var $0 = $$.length - 1;
@@ -565,7 +566,8 @@ stateStackSize:function stateStackSize() {
         return this.conditionStack.length;
     },
 options: {},
-performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START) {
+performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START
+/**/) {
 
 var YYSTATE=YY_START;
 switch($avoiding_name_collisions) {


### PR DESCRIPTION
This change records unrecognized decls in an `unknownDecl` key on the final result rather than just dropping them on the floor. This may be useful for applications that wish to do preprocessing on the grammar based on these declarations before handing it off to Jison to compile into a parser.
